### PR TITLE
Fix role for RHEL 7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: rhel.yml
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'RedHat'
 - include: ubuntu.yml
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 


### PR DESCRIPTION
This PR allows this role to run on RHEL7 servers.

I have RedHat 7.3 and RedHat 7.4 servers and this role isn't running against them :( Here are the `ansible_distribution` vars on these servers:

```
$ ansible -m setup <<hostname redacted>> | grep 'ansible_distribution'
        "ansible_distribution": "RedHat", 
        "ansible_distribution_major_version": "7", 
        "ansible_distribution_release": "Maipo", 
        "ansible_distribution_version": "7.3",
```

```
$ ansible -m setup <<hostname redacted>> | grep 'ansible_distribution'
        "ansible_distribution": "RedHat", 
        "ansible_distribution_major_version": "7", 
        "ansible_distribution_release": "Maipo", 
        "ansible_distribution_version": "7.4",
```