### PR TITLE
support ansible_distribution Amazon for amazon linux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: rhel.yml
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'RedHat'
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Amazon'
 - include: ubuntu.yml
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 


### PR DESCRIPTION
Currently this role fails when running on an Amazon linux machine, because `ansible_distribution` is set to `Amazon`. I've tested this commit already and the role ran successfully.