### PR TITLE
Fix yarn role for new ansible

### DIFF
--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -7,10 +7,6 @@
   apt_key:
     url: "{{ yarn_debian_repo_gpg_key_url }}"
     state: present
-  register: result
-  until: '"failed" not in result'
-  retries: 3
-  delay: 5
   when: not yarn_repofile_result.stat.exists
 
 - name: Install YARN APT repo.
@@ -18,8 +14,4 @@
     repo: "deb {{ yarn_debian_repo_url }}"
     filename: "yarn"
     state: present
-  register: result
-  until: '"failed" not in result'
-  retries: 3
-  delay: 5
   when: not yarn_repofile_result.stat.exists


### PR DESCRIPTION
Hello!

It looks like register/until/retries/delay combos don't work anymore (I tested role on Ansible 2.5.0)
<del>I also updated urls to use HTTPS protocol (GPG keys should be downloaded via HTTPS to prevent MITM attacks) </del>
