### PR TITLE
Fix RHEL task by checking GPG key file for repo

### DIFF
--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -6,7 +6,7 @@
     baseurl: "{{ yarn_rhel_repo_url }}"
     enabled: yes
     gpgcheck: yes
-    gpgcakey: "{{ yarn_rhel_repo_gpg_key_url }}"
+    gpgkey: "{{ yarn_rhel_repo_gpg_key_url }}"
     state: present
 
 - name: Install NodeJS package for yarn dependency


### PR DESCRIPTION
The RHEL task was using `gpgcakey` which checks the CA key
file for the repository. The file that was actually being
loaded was the GPG key, so we should e using [`gpgkey` instead](https://docs.ansible.com/ansible/2.3/yum_repository_module.html).